### PR TITLE
Gem mini_racer 記述修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'kaminari-bootstrap'
 gem 'faker'
 gem 'dotenv-rails'
 gem 'unicorn'
-gem 'mini_racer'
+gem 'mini_racer', platforms: :ruby
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
gem mini_racerに platforms: :rubyを追記 